### PR TITLE
Specify provider with the vendor:publish command

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Samrap\Validation\ValidationServiceProvider::class
 
 Finally, the base `Validator` class needs to be published to a new `app/Validators` directory. This can be done using the `vendor:publish` command:
 
-`php artisan vendor:publish`
+`php artisan vendor:publish --provider="Samrap\Validation\ValidationServiceProvider"`
 
 ### Usage
 ---


### PR DESCRIPTION
This PR makes sure we specify the provider for which to publish the vendor files. Without this, it will publish the assets from all vendors and that might have unintended side effects for some users.
